### PR TITLE
Fix for calliope makecode

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -1,7 +1,7 @@
 {
     "name": "pxt-flexfx",
     "version": "2.2.7",
-    "description": "micro:bit (V2) extension for flexible re-usable sound effects",
+    "description": "Calliope mini 3 extension for flexible re-usable sound effects",
     "license": "MIT",
     "dependencies": {
         "core": "*",

--- a/pxt.json
+++ b/pxt.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "dependencies": {
         "core": "*",
-        "core-mini-codal": "*"
+        "v3": "*"
     },
     "files": [
         "flexFX.ts",
@@ -20,12 +20,7 @@
     },
     "supportedTargets": [
         "microbit"
-    ],
-    "compileServiceVariant": "minicodal",
-    "disablesVariants": [
-        "minidal",
-        "minidalusb"
-    ],
+    ]
     "preferredEditor": "tsprj",
     "disablesVariants": [
         "mbdal"

--- a/pxt.json
+++ b/pxt.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "dependencies": {
         "core": "*",
-        "v3": "*"
+        "core-mini-codal": "*"
     },
     "files": [
         "flexFX.ts",

--- a/pxt.json
+++ b/pxt.json
@@ -19,10 +19,12 @@
         "targetId": "calliopemini"
     },
     "supportedTargets": [
-        "microbit"
+        "calliopemini"
     ],
     "preferredEditor": "tsprj",
+    "compileServiceVariant": "minicodal",
     "disablesVariants": [
-        "mbdal"
+        "minidal",
+        "minidalusb"
     ]
 }

--- a/pxt.json
+++ b/pxt.json
@@ -21,6 +21,11 @@
     "supportedTargets": [
         "microbit"
     ],
+    "compileServiceVariant": "minicodal",
+    "disablesVariants": [
+        "minidal",
+        "minidalusb"
+    ],
     "preferredEditor": "tsprj",
     "disablesVariants": [
         "mbdal"

--- a/pxt.json
+++ b/pxt.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "dependencies": {
         "core": "*",
-        "core-mini-codal": "*"
+        "v3": "*"
     },
     "files": [
         "flexFX.ts",

--- a/pxt.json
+++ b/pxt.json
@@ -4,7 +4,8 @@
     "description": "micro:bit (V2) extension for flexible re-usable sound effects",
     "license": "MIT",
     "dependencies": {
-        "core": "*"
+        "core": "*",
+        "core-mini-codal": "*"
     },
     "files": [
         "flexFX.ts",

--- a/pxt.json
+++ b/pxt.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "dependencies": {
         "core": "*",
-        "core-mini-codal": "*"
+        "v3": "*"
     },
     "files": [
         "flexFX.ts",
@@ -21,10 +21,5 @@
     "supportedTargets": [
         "calliopemini"
     ],
-    "preferredEditor": "tsprj",
-    "compileServiceVariant": "minicodal",
-    "disablesVariants": [
-        "minidal",
-        "minidalusb"
-    ]
+    "preferredEditor": "tsprj"
 }

--- a/pxt.json
+++ b/pxt.json
@@ -20,7 +20,7 @@
     },
     "supportedTargets": [
         "microbit"
-    ]
+    ],
     "preferredEditor": "tsprj",
     "disablesVariants": [
         "mbdal"


### PR DESCRIPTION
Dependencies must be either `v3` or `core-mini-codal` additional to `core`:
```
    "dependencies": {
        "core": "*",
        "core-mini-codal": "*"
    }
```